### PR TITLE
Fixed loki log directory

### DIFF
--- a/heplify-server/hom7-hep-prom-loki-graf/loki/promtail-docker-config.yaml
+++ b/heplify-server/hom7-hep-prom-loki-graf/loki/promtail-docker-config.yaml
@@ -16,4 +16,4 @@ scrape_configs:
       - localhost
     labels:
       job: varlogs
-      __path__: /var/log
+      __path__: /var/log/*log


### PR DESCRIPTION
When starting with docker compose, Loki complains that it's trying to read the logs of a directory, this fixes that. 

![image](https://user-images.githubusercontent.com/16978632/54728511-64ed4f00-4bd2-11e9-9af2-7b272692ae35.png)

`promtail          | level=error ts=2019-03-21T01:04:07.45147109Z caller=filetarget.go:251 msg="failed to tail file" error="file is a directory" filename=/var/log`

Matches path in official repo: https://github.com/grafana/loki/blob/d495c68ef90a028fb50917c03a983a1e3b979b0a/cmd/promtail/promtail-docker-config.yaml#L19