### PR TITLE
Restart behaviour for Adminer and Promtail

### DIFF
--- a/heplify-server/hom7-hep-prom-graf/docker-compose.yml
+++ b/heplify-server/hom7-hep-prom-graf/docker-compose.yml
@@ -106,6 +106,7 @@ services:
       retries: 30
   admin:
     image: adminer
+    restart: unless-stopped
     depends_on: 
       - db
     ports:

--- a/heplify-server/hom7-hep-prom-loki-graf/docker-compose.yml
+++ b/heplify-server/hom7-hep-prom-loki-graf/docker-compose.yml
@@ -94,6 +94,7 @@ services:
     volumes:
       - ./loki/promtail-docker-config.yaml:/etc/promtail/promtail-docker-config.yaml
       - /var/log:/var/log
+    restart: unless-stopped
     command: "-config.file=/etc/promtail/promtail-docker-config.yaml"
 
   caddy:


### PR DESCRIPTION
Not sure if this is deliberate but these containers didn't have the restart behaviour set which meant they wouldn't automatically start after a system reboot

Other containers in the docker-compose file had the behaviour set