### PR TITLE
Changed retention flag

### DIFF
--- a/heplify-server/hom5-hep-prom-graf/docker-compose.yml
+++ b/heplify-server/hom5-hep-prom-graf/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/etc/prometheus/console_libraries'
       - '--web.console.templates=/etc/prometheus/consoles'
-      - '--storage.tsdb.retention=30d'
+      - '--storage.tsdb.retention.time=30d'
       - '--web.enable-lifecycle'
     restart: unless-stopped
     expose:

--- a/heplify-server/hom7-hep-prom-graf/docker-compose.yml
+++ b/heplify-server/hom7-hep-prom-graf/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/etc/prometheus/console_libraries'
       - '--web.console.templates=/etc/prometheus/consoles'
-      - '--storage.tsdb.retention=30d'
+      - '--storage.tsdb.retention.time=30d'
       - '--web.enable-lifecycle'
     restart: unless-stopped
     expose:

--- a/heplify-server/hom7-hep-prom-loki-graf/docker-compose.yml
+++ b/heplify-server/hom7-hep-prom-loki-graf/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/etc/prometheus/console_libraries'
       - '--web.console.templates=/etc/prometheus/consoles'
-      - '--storage.tsdb.retention=30d'
+      - '--storage.tsdb.retention.time=30d'
       - '--web.enable-lifecycle'
     restart: unless-stopped
     expose:

--- a/heplify-server/hom7-prom-all/docker-compose.yml
+++ b/heplify-server/hom7-prom-all/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/etc/prometheus/console_libraries'
       - '--web.console.templates=/etc/prometheus/consoles'
-      - '--storage.tsdb.retention=30d'
+      - '--storage.tsdb.retention.time=30d'
       - '--web.enable-lifecycle'
     restart: unless-stopped
     expose:


### PR DESCRIPTION
From https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects

> --storage.tsdb.retention: This flag has been deprecated in favour of storage.tsdb.retention.time.

Also

> --storage.tsdb.retention.time: This determines when to remove old data. Defaults to 15d. **Overrides storage.tsdb.retention if this flag is set to anything other than default.**

