### PR TITLE
only local access to kibana

### DIFF
--- a/heplify-server/hom7-hep-elastic/docker-compose.yml
+++ b/heplify-server/hom7-hep-elastic/docker-compose.yml
@@ -103,7 +103,7 @@ services:
     image: docker.elastic.co/kibana/kibana-oss:6.3.1
     container_name: kibana
     ports:
-      - "5601:5601"
+      - "127.0.0.1:5601:5601"
     depends_on:
       - elasticsearch
 


### PR DESCRIPTION
login only through a proxy caddy, because on port 5601, without password access.