### PR TITLE
Minimal update to work

### DIFF
--- a/heplify-server/hom7-hep-prom-loki-graf/loki/loki-local-config.yaml
+++ b/heplify-server/hom7-hep-prom-loki-graf/loki/loki-local-config.yaml
@@ -7,13 +7,14 @@ ingester:
   lifecycler:
     address: 127.0.0.1
     ring:
-      store: inmemory
+      kvstore:
+        store: inmemory
       replication_factor: 1
   chunk_idle_period: 15m
 
 schema_config:
   configs:
-  - from: 0
+  - from: 2019-10-01
     store: boltdb
     object_store: filesystem
     schema: v9


### PR DESCRIPTION
By default config doesn't work.
log messages:
` 
level=error ts=2019-10-26T06:00:24.768647875Z caller=main.go:48 msg="error loading config" filename=/etc/loki/loki-local-config.yaml err="parsing time \"0\" as \"2006-01-02\": cannot parse \"0\" as \"2006\""
`

and

`
level=error ts=2019-10-26T06:03:28.568204624Z caller=main.go:48 msg="error loading config" filename=/etc/loki/loki-local-config.yaml err="yaml: unmarshal errors:\n  line 10: field store not found in type ring.Config"
`

Checked with loki github official config and updated.
I don't know about loki, but this is working