### PR TITLE
Cleanup Docker Compose files

### DIFF
--- a/heplify-server/hom7-influx-tick/docker-compose.yml
+++ b/heplify-server/hom7-influx-tick/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   caddy:
     container_name: caddy
     image: stefanprodan/caddy
-    container_name: caddy
     ports:
       - "3000:3000"
       - "9090:9090"
@@ -21,13 +20,12 @@ services:
 
   db:
     image: postgres:11-alpine
-    restart: always
+    restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: homerSeven
       POSTGRES_USER: root
     expose:
       - 5432
-    restart: unless-stopped
     volumes:
       - ./conf/init-user-db.sh:/docker-entrypoint-initdb.d/init-user-db.sh
       - ./postgres-data:/var/lib/postgresql/data
@@ -158,15 +156,14 @@ services:
         echo InfluxDB Retention Policy push ...;
         curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE DATABASE homer'
         curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE RETENTION POLICY "60s" ON "homer" DURATION 4w REPLICATION 1 DEFAULT'
+        curl -G http://influxdb:8086/query --data-urlencode 'q=drop retention policy "autogen" ON "homer"'
+        echo Chronograf Dashboard push ...;
+        curl -i -X POST -H "Content-Type: application/json" http://chronograf/chronograf/v1/dashboards -d @/tmp/homer_dashboard.json
+        echo Provisioning completed! Exiting ...;
+        poweroff;
 #        curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE RETENTION POLICY "300s" ON "homer" DURATION 8w REPLICATION 1'
 #        curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE RETENTION POLICY "3600s" ON "homer" DURATION 16w REPLICATION 1'
 #        curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE RETENTION POLICY "86400s" ON "homer" DURATION 32w REPLICATION 1'
 #        curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE CONTINUOUS QUERY cq_300s ON homer RESAMPLE EVERY 1m BEGIN SELECT mean(*) INTO homer."300s".:MEASUREMENT FROM homer."60s"./.*/ GROUP BY time(5m),* END'
 #        curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE CONTINUOUS QUERY cq_3600s ON homer RESAMPLE EVERY 10m BEGIN SELECT mean(*) INTO homer."3600s".:MEASUREMENT FROM homer."60s"./.*/ GROUP BY time(1h),* END'
 #        curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE CONTINUOUS QUERY cq_86400s ON homer RESAMPLE EVERY 1h BEGIN SELECT mean(*) INTO homer."86400s".:MEASUREMENT FROM homer."60s"./.*/ GROUP BY time(1d),* END'
-        curl -G http://influxdb:8086/query --data-urlencode 'q=drop retention policy "autogen" ON "homer"'
-        echo Chronograf Dashboard push ...;
-        curl -i -X POST -H "Content-Type: application/json" http://chronograf/chronograf/v1/dashboards -d @/tmp/homer_dashboard.json
-        echo Provisioning completed! Exiting ...;
-        poweroff;
-

--- a/heplify-server/hom7-prom-all/docker-compose.yml
+++ b/heplify-server/hom7-prom-all/docker-compose.yml
@@ -174,7 +174,6 @@ services:
   db:
     container_name: db
     image: postgres:11-alpine
-    restart: always
     environment:
       POSTGRES_PASSWORD: homerSeven
       POSTGRES_USER: root

--- a/heplify-server/hom7-timescaledb-all/docker-compose.yml
+++ b/heplify-server/hom7-timescaledb-all/docker-compose.yml
@@ -135,7 +135,6 @@ services:
   db:
     container_name: db
     image: timescale/timescaledb:latest-pg11
-    restart: always
     environment:
       POSTGRES_PASSWORD: homerSeven
       POSTGRES_USER: root

--- a/hepop/hom7-elastic-only/docker-compose.yml
+++ b/hepop/hom7-elastic-only/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   caddy:
     container_name: caddy
     image: stefanprodan/caddy
-    container_name: caddy
     ports:
       - "9090:9090"
     volumes:

--- a/hepop/hom7-hep-influx/docker-compose.yml
+++ b/hepop/hom7-hep-influx/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   caddy:
     container_name: caddy
     image: stefanprodan/caddy
-    container_name: caddy
     ports:
       - "3000:3000"
       - "9090:9090"
@@ -21,7 +20,6 @@ services:
 
   db:
     image: postgres:11-alpine
-    restart: always
     environment:
       POSTGRES_PASSWORD: homerSeven
       POSTGRES_USER: root
@@ -148,4 +146,3 @@ services:
         curl -i -X POST -H "Content-Type: application/json" http://chronograf/chronograf/v1/dashboards -d @/tmp/homer_dashboard.json
         echo Provisioning completed! Exiting ...;
         poweroff;
-

--- a/hepop/hom7-json-influx/docker-compose.yml
+++ b/hepop/hom7-json-influx/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   caddy:
     container_name: caddy
     image: stefanprodan/caddy
-    container_name: caddy
     ports:
       - "3000:3000"
       - "9090:9090"
@@ -21,7 +20,6 @@ services:
 
   db:
     image: postgres:11-alpine
-    restart: always
     environment:
       POSTGRES_PASSWORD: homerSeven
       POSTGRES_USER: root
@@ -150,4 +148,3 @@ services:
         curl -i -X POST -H "Content-Type: application/json" http://chronograf/chronograf/v1/dashboards -d @/tmp/homer_dashboard.json
         echo Provisioning completed! Exiting ...;
         poweroff;
-

--- a/hepop/hom7-json-loki/docker-compose.yml
+++ b/hepop/hom7-json-loki/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   caddy:
     container_name: caddy
     image: stefanprodan/caddy
-    container_name: caddy
     ports:
       - "3000:3000"
       - "9090:9090"
@@ -21,7 +20,6 @@ services:
 
   db:
     image: postgres:11-alpine
-    restart: always
     environment:
       POSTGRES_PASSWORD: homerSeven
       POSTGRES_USER: root

--- a/hepop/hom7-loudml-influx/docker-compose.yml
+++ b/hepop/hom7-loudml-influx/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   caddy:
     container_name: caddy
     image: stefanprodan/caddy
-    container_name: caddy
     ports:
       - "9090:9090"
       - "9080:9080"
@@ -19,7 +18,6 @@ services:
 
   db:
     image: postgres:11-alpine
-    restart: always
     environment:
       POSTGRES_PASSWORD: homerSeven
       POSTGRES_USER: root
@@ -35,7 +33,7 @@ services:
       timeout: 3s
       retries: 30
 
-heplify-server:
+  heplify-server:
     image: sipcapture/hepop:master
     container_name: heplify-server
     ports:
@@ -164,4 +162,3 @@ heplify-server:
         curl -i -X POST -H "Content-Type: application/json" http://chronograf/chronograf/v1/dashboards -d @/tmp/homer_dashboard.json
         echo Provisioning completed! Exiting ...;
         poweroff;
-

--- a/hepop/hom7-rtc-grafana-insecure/docker-compose.yml
+++ b/hepop/hom7-rtc-grafana-insecure/docker-compose.yml
@@ -7,116 +7,114 @@ volumes:
     ssl_data: {}
 
 services:
+  self-signed-certificate-generator:
+    image: magnitus/certificate-generator:latest
+    environment:
+      COUNTRY: NL
+      STATE: Noord-Holland
+      CITY: Amsterdam
+      ORGANIZATION: Any
+      DEPARTMENT: IT
+      EMAIL: email@mydomain.com
+      DOMAINS: dev.mydomain.com;test.mydomain.com
+      CERTIFICATE_DURATION: 1095
+      KEY_FILE: "cert.key"
+      CSR_FILE: "cert.csr"
+      CERTIFICATE_FILE: "cert.crt"
+      OUTPUT_CERTIFICATE_INFO: "true"
+    volumes:
+      - ssl_data:/opt/output
 
-    self-signed-certificate-generator:
-      image: magnitus/certificate-generator:latest
-      environment:
-        COUNTRY: NL
-        STATE: Noord-Holland
-        CITY: Amsterdam
-        ORGANIZATION: Any
-        DEPARTMENT: IT
-        EMAIL: email@mydomain.com
-        DOMAINS: dev.mydomain.com;test.mydomain.com
-        CERTIFICATE_DURATION: 1095
-        KEY_FILE: "cert.key"
-        CSR_FILE: "cert.csr"
-        CERTIFICATE_FILE: "cert.crt"
-        OUTPUT_CERTIFICATE_INFO: "true"
-      volumes:
-        - ssl_data:/opt/output
+  hepop:
+    image: sipcapture/hepop:master
+    container_name: hepop
+    volumes:
+      - ${CONFIG}/web:/config
+      - ssl_data:/ssl
+      - ./config/myconfig.js:/app/myconfig.js
+    ports:
+      - "9069:8080"
+      - "9060:9060"
+      - "9060:9060/udp"
+    environment:
+      HEPOP_DEBUG: 'true'
+    restart: unless-stopped
+    expose:
+      - 9069
+      - 9060
+    depends_on:
+      - grafana
+      - loki
+    networks:
+      homer.server:
 
-    hepop:
-      image: sipcapture/hepop:master
-      container_name: hepop
-      volumes:
-        - ${CONFIG}/web:/config
-        - ssl_data:/ssl
-        - ./config/myconfig.js:/app/myconfig.js
-      ports:
-        - "9069:8080"
-        - "9060:9060"
-        - "9060:9060/udp"
-      environment:
-        HEPOP_DEBUG: 'true'
-      restart: unless-stopped
-      expose:
-        - 9069
-        - 9060
-      depends_on:
-        - grafana
-        - loki
-      networks:
-        homer.server:
+  loki:
+    image: grafana/loki:master 
+    container_name: loki
+    volumes:
+      - ./config/loki-local-config.yaml:/etc/loki/loki-local-config.yaml
+    restart: unless-stopped
+    expose:
+      - 3100
+    ports:
+      - "3100:3100"
+    command: "-config.file=/etc/loki/loki-local-config.yaml" 
+    networks:
+      homer.server:
 
-    loki:
-      image: grafana/loki:master 
-      container_name: loki
-      volumes:
-        - ./config/loki-local-config.yaml:/etc/loki/loki-local-config.yaml
-      restart: unless-stopped
-      expose:
-        - 3100
-      ports:
-        - "3100:3100"
-      command: "-config.file=/etc/loki/loki-local-config.yaml" 
-      networks:
-        homer.server:
+  influxdb:
+    container_name: influxdb
+    image: influxdb:1.7-alpine
+    volumes:
+      - influx_data:/var/lib/influxdb
+    ports:
+      - "8086:8086"
+    expose:
+      - 8086
+    networks:
+      homer.server:
 
-    influxdb:
-      container_name: influxdb
-      image: influxdb:1.7-alpine
-      volumes:
-        - influx_data:/var/lib/influxdb
-      ports:
-        - "8086:8086"
-      expose:
-        - 8086
-      networks:
-        homer.server:
+  grafana:
+    image: grafana/grafana:master
+    container_name: grafana
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning/:/etc/grafana/provisioning/
+    environment:
+      - GF_SECURITY_ADMIN_USER=${ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${ADMIN_PASSWORD:-sipcapture}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_EXPLORE_ENABLED=true
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    expose:
+      - 3000
+    networks:
+      homer.server:
 
-    grafana:
-      image: grafana/grafana:master
-      container_name: grafana
-      volumes:
-        - grafana_data:/var/lib/grafana
-        - ./grafana/provisioning/:/etc/grafana/provisioning/
-      environment:
-        - GF_SECURITY_ADMIN_USER=${ADMIN_USER:-admin}
-        - GF_SECURITY_ADMIN_PASSWORD=${ADMIN_PASSWORD:-sipcapture}
-        - GF_USERS_ALLOW_SIGN_UP=false
-        - GF_EXPLORE_ENABLED=true
-      restart: unless-stopped
-      ports:
-        - "3000:3000"
-      expose:
-        - 3000
-      networks:
-        homer.server:
-
-    provisioning:
-      image: alpine:latest
-      networks:
-        homer.server:
-      depends_on:
-        - influxdb
-      links:
-        - influxdb
-      command: 
-        - /bin/sh
-        - -c
-        - |
-          apk add --no-cache curl;
-          echo Waiting for influxdb API ...;
-          while ! nc -z influxdb 8086;
-          do
-            sleep 2;
-          done;
-          echo InfluxDB Retention Policy push ...;
-          curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE DATABASE hep'
-          echo Provisioning completed! Exiting ...;
-          poweroff;
-
+  provisioning:
+    image: alpine:latest
+    networks:
+      homer.server:
+    depends_on:
+      - influxdb
+    links:
+      - influxdb
+    command: 
+      - /bin/sh
+      - -c
+      - |
+        apk add --no-cache curl;
+        echo Waiting for influxdb API ...;
+        while ! nc -z influxdb 8086;
+        do
+          sleep 2;
+        done;
+        echo InfluxDB Retention Policy push ...;
+        curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE DATABASE hep'
+        echo Provisioning completed! Exiting ...;
+        poweroff;
 
 # Custom network so all services can communicate using a FQDN
 networks:

--- a/hepop/hom7-rtc-grafana/docker-compose.yml
+++ b/hepop/hom7-rtc-grafana/docker-compose.yml
@@ -7,116 +7,114 @@ volumes:
     ssl_data: {}
 
 services:
+  self-signed-certificate-generator:
+    image: magnitus/certificate-generator:latest
+    environment:
+      COUNTRY: NL
+      STATE: Noord-Holland
+      CITY: Amsterdam
+      ORGANIZATION: Any
+      DEPARTMENT: IT
+      EMAIL: email@mydomain.com
+      DOMAINS: dev.mydomain.com;test.mydomain.com
+      CERTIFICATE_DURATION: 1095
+      KEY_FILE: "cert.key"
+      CSR_FILE: "cert.csr"
+      CERTIFICATE_FILE: "cert.crt"
+      OUTPUT_CERTIFICATE_INFO: "true"
+    volumes:
+      - ssl_data:/opt/output
 
-    self-signed-certificate-generator:
-      image: magnitus/certificate-generator:latest
-      environment:
-        COUNTRY: NL
-        STATE: Noord-Holland
-        CITY: Amsterdam
-        ORGANIZATION: Any
-        DEPARTMENT: IT
-        EMAIL: email@mydomain.com
-        DOMAINS: dev.mydomain.com;test.mydomain.com
-        CERTIFICATE_DURATION: 1095
-        KEY_FILE: "cert.key"
-        CSR_FILE: "cert.csr"
-        CERTIFICATE_FILE: "cert.crt"
-        OUTPUT_CERTIFICATE_INFO: "true"
-      volumes:
-        - ssl_data:/opt/output
+  hepop:
+    image: sipcapture/hepop:master
+    container_name: hepop
+    volumes:
+      - ${CONFIG}/web:/config
+      - ssl_data:/ssl
+      - ./config/myconfig.js:/app/myconfig.js
+    ports:
+      - "9069:8080"
+      - "9060:9060"
+      - "9060:9060/udp"
+    environment:
+      HEPOP_DEBUG: 'true'
+    restart: unless-stopped
+    expose:
+      - 9069
+      - 9060
+    depends_on:
+      - grafana
+      - loki
+    networks:
+      homer.server:
 
-    hepop:
-      image: sipcapture/hepop:master
-      container_name: hepop
-      volumes:
-        - ${CONFIG}/web:/config
-        - ssl_data:/ssl
-        - ./config/myconfig.js:/app/myconfig.js
-      ports:
-        - "9069:8080"
-        - "9060:9060"
-        - "9060:9060/udp"
-      environment:
-        HEPOP_DEBUG: 'true'
-      restart: unless-stopped
-      expose:
-        - 9069
-        - 9060
-      depends_on:
-        - grafana
-        - loki
-      networks:
-        homer.server:
+  loki:
+    image: grafana/loki:master 
+    container_name: loki
+    volumes:
+      - ./config/loki-local-config.yaml:/etc/loki/loki-local-config.yaml
+    restart: unless-stopped
+    expose:
+      - 3100
+    ports:
+      - "3100:3100"
+    command: "-config.file=/etc/loki/loki-local-config.yaml" 
+    networks:
+      homer.server:
 
-    loki:
-      image: grafana/loki:master 
-      container_name: loki
-      volumes:
-        - ./config/loki-local-config.yaml:/etc/loki/loki-local-config.yaml
-      restart: unless-stopped
-      expose:
-        - 3100
-      ports:
-        - "3100:3100"
-      command: "-config.file=/etc/loki/loki-local-config.yaml" 
-      networks:
-        homer.server:
+  influxdb:
+    container_name: influxdb
+    image: influxdb:1.7-alpine
+    volumes:
+      - influx_data:/var/lib/influxdb
+    ports:
+      - "8086:8086"
+    expose:
+      - 8086
+    networks:
+      homer.server:
 
-    influxdb:
-      container_name: influxdb
-      image: influxdb:1.7-alpine
-      volumes:
-        - influx_data:/var/lib/influxdb
-      ports:
-        - "8086:8086"
-      expose:
-        - 8086
-      networks:
-        homer.server:
+  grafana:
+    image: grafana/grafana:master
+    container_name: grafana
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning/:/etc/grafana/provisioning/
+    environment:
+      - GF_SECURITY_ADMIN_USER=${ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${ADMIN_PASSWORD:-sipcapture}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_EXPLORE_ENABLED=true
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    expose:
+      - 3000
+    networks:
+      homer.server:
 
-    grafana:
-      image: grafana/grafana:master
-      container_name: grafana
-      volumes:
-        - grafana_data:/var/lib/grafana
-        - ./grafana/provisioning/:/etc/grafana/provisioning/
-      environment:
-        - GF_SECURITY_ADMIN_USER=${ADMIN_USER:-admin}
-        - GF_SECURITY_ADMIN_PASSWORD=${ADMIN_PASSWORD:-sipcapture}
-        - GF_USERS_ALLOW_SIGN_UP=false
-        - GF_EXPLORE_ENABLED=true
-      restart: unless-stopped
-      ports:
-        - "3000:3000"
-      expose:
-        - 3000
-      networks:
-        homer.server:
-
-    provisioning:
-      image: alpine:latest
-      networks:
-        homer.server:
-      depends_on:
-        - influxdb
-      links:
-        - influxdb
-      command: 
-        - /bin/sh
-        - -c
-        - |
-          apk add --no-cache curl;
-          echo Waiting for influxdb API ...;
-          while ! nc -z influxdb 8086;
-          do
-            sleep 2;
-          done;
-          echo InfluxDB Retention Policy push ...;
-          curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE DATABASE hep'
-          echo Provisioning completed! Exiting ...;
-          poweroff;
-
+  provisioning:
+    image: alpine:latest
+    networks:
+      homer.server:
+    depends_on:
+      - influxdb
+    links:
+      - influxdb
+    command: 
+      - /bin/sh
+      - -c
+      - |
+        apk add --no-cache curl;
+        echo Waiting for influxdb API ...;
+        while ! nc -z influxdb 8086;
+        do
+          sleep 2;
+        done;
+        echo InfluxDB Retention Policy push ...;
+        curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE DATABASE hep'
+        echo Provisioning completed! Exiting ...;
+        poweroff;
 
 # Custom network so all services can communicate using a FQDN
 networks:

--- a/hepop/hom7-rtc-janus/docker-compose.yml
+++ b/hepop/hom7-rtc-janus/docker-compose.yml
@@ -7,138 +7,135 @@ volumes:
     ssl_data: {}
 
 services:
+  self-signed-certificate-generator:
+    image: magnitus/certificate-generator:latest
+    environment:
+      COUNTRY: NL
+      STATE: Noord-Holland
+      CITY: Amsterdam
+      ORGANIZATION: Any
+      DEPARTMENT: IT
+      EMAIL: email@mydomain.com
+      DOMAINS: dev.mydomain.com;test.mydomain.com
+      CERTIFICATE_DURATION: 1095
+      KEY_FILE: "cert.key"
+      CSR_FILE: "cert.csr"
+      CERTIFICATE_FILE: "cert.crt"
+      OUTPUT_CERTIFICATE_INFO: "true"
+    volumes:
+      - ssl_data:/opt/output
 
-    self-signed-certificate-generator:
-      image: magnitus/certificate-generator:latest
-      environment:
-        COUNTRY: NL
-        STATE: Noord-Holland
-        CITY: Amsterdam
-        ORGANIZATION: Any
-        DEPARTMENT: IT
-        EMAIL: email@mydomain.com
-        DOMAINS: dev.mydomain.com;test.mydomain.com
-        CERTIFICATE_DURATION: 1095
-        KEY_FILE: "cert.key"
-        CSR_FILE: "cert.csr"
-        CERTIFICATE_FILE: "cert.crt"
-        OUTPUT_CERTIFICATE_INFO: "true"
-      volumes:
-        - ssl_data:/opt/output
+  hepop:
+    image: sipcapture/hepop:master
+    container_name: hepop
+    volumes:
+      - ${CONFIG}/web:/config
+      - ssl_data:/ssl
+      - ./config/myconfig.js:/app/myconfig.js
+    ports:
+      - "9069:8080"
+      - "9060:9060"
+      - "9060:9060/udp"
+    environment:
+      HEPOP_DEBUG: 'true'
+    restart: unless-stopped
+    expose:
+      - 9069
+      - 9060
+    depends_on:
+      - grafana
+      - loki
+    networks:
+      homer.server:
 
-    hepop:
-      image: sipcapture/hepop:master
-      container_name: hepop
-      volumes:
-        - ${CONFIG}/web:/config
-        - ssl_data:/ssl
-        - ./config/myconfig.js:/app/myconfig.js
-      ports:
-        - "9069:8080"
-        - "9060:9060"
-        - "9060:9060/udp"
-      environment:
-        HEPOP_DEBUG: 'true'
-      restart: unless-stopped
-      expose:
-        - 9069
-        - 9060
-      depends_on:
-        - grafana
-        - loki
-      networks:
-        homer.server:
+  loki:
+    image: grafana/loki:master 
+    container_name: loki
+    volumes:
+      - ./config/loki-local-config.yaml:/etc/loki/loki-local-config.yaml
+    restart: unless-stopped
+    expose:
+      - 3100
+    ports:
+      - "3100:3100"
+    command: "-config.file=/etc/loki/loki-local-config.yaml" 
+    networks:
+      homer.server:
 
-    loki:
-      image: grafana/loki:master 
-      container_name: loki
-      volumes:
-        - ./config/loki-local-config.yaml:/etc/loki/loki-local-config.yaml
-      restart: unless-stopped
-      expose:
-        - 3100
-      ports:
-        - "3100:3100"
-      command: "-config.file=/etc/loki/loki-local-config.yaml" 
-      networks:
-        homer.server:
+  influxdb:
+    container_name: influxdb
+    image: influxdb:1.7-alpine
+    volumes:
+      - influx_data:/var/lib/influxdb
+    ports:
+      - "8086:8086"
+    expose:
+      - 8086
+    networks:
+      homer.server:
 
-    influxdb:
-      container_name: influxdb
-      image: influxdb:1.7-alpine
-      volumes:
-        - influx_data:/var/lib/influxdb
-      ports:
-        - "8086:8086"
-      expose:
-        - 8086
-      networks:
-        homer.server:
+  grafana:
+    image: grafana/grafana:master
+    container_name: grafana
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning/:/etc/grafana/provisioning/
+    environment:
+      - GF_SECURITY_ADMIN_USER=${ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${ADMIN_PASSWORD:-sipcapture}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_EXPLORE_ENABLED=true
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    expose:
+      - 3000
+    networks:
+      homer.server:
 
-    grafana:
-      image: grafana/grafana:master
-      container_name: grafana
-      volumes:
-        - grafana_data:/var/lib/grafana
-        - ./grafana/provisioning/:/etc/grafana/provisioning/
-      environment:
-        - GF_SECURITY_ADMIN_USER=${ADMIN_USER:-admin}
-        - GF_SECURITY_ADMIN_PASSWORD=${ADMIN_PASSWORD:-sipcapture}
-        - GF_USERS_ALLOW_SIGN_UP=false
-        - GF_EXPLORE_ENABLED=true
-      restart: unless-stopped
-      ports:
-        - "3000:3000"
-      expose:
-        - 3000
-      networks:
-        homer.server:
+  provisioning:
+    image: alpine:latest
+    networks:
+      homer.server:
+    depends_on:
+      - influxdb
+    links:
+      - influxdb
+    command: 
+      - /bin/sh
+      - -c
+      - |
+        apk add --no-cache curl;
+        echo Waiting for influxdb API ...;
+        while ! nc -z influxdb 8086;
+        do
+          sleep 2;
+        done;
+        echo InfluxDB Retention Policy push ...;
+        curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE DATABASE hep'
+        echo Provisioning completed! Exiting ...;
+        poweroff;
 
-    provisioning:
-      image: alpine:latest
-      networks:
-        homer.server:
-      depends_on:
-        - influxdb
-      links:
-        - influxdb
-      command: 
-        - /bin/sh
-        - -c
-        - |
-          apk add --no-cache curl;
-          echo Waiting for influxdb API ...;
-          while ! nc -z influxdb 8086;
-          do
-            sleep 2;
-          done;
-          echo InfluxDB Retention Policy push ...;
-          curl -G http://influxdb:8086/query --data-urlencode 'q=CREATE DATABASE hep'
-          echo Provisioning completed! Exiting ...;
-          poweroff;
-
-
-    janus-gateway:
-      image: hepic/janus-gateway
-      container_name: janus
-      ports:
-        - "7889:7889"
-        - "8080:8080"
-        - "8089:8089"
-        - "8088:8088"
-        - "8188:8188"
-        - "7889:7889"
-        - "10000-10200:10000-10200/udp"
-      volumes:
-        - ssl_data:/ssl
-        - ./config/janus.jcfg:/opt/janus/etc/janus/janus.jcfg
-        - ./config/janus.transport.http.jcfg:/opt/janus/etc/janus/janus.transport.http.jcfg
-        - ./config/janus.eventhandler.sampleevh.jcfg:/opt/janus/etc/janus/janus.eventhandler.sampleevh.jcfg
+  janus-gateway:
+    image: hepic/janus-gateway
+    container_name: janus
+    ports:
+      - "7889:7889"
+      - "8080:8080"
+      - "8089:8089"
+      - "8088:8088"
+      - "8188:8188"
+      - "7889:7889"
+      - "10000-10200:10000-10200/udp"
+    volumes:
+      - ssl_data:/ssl
+      - ./config/janus.jcfg:/opt/janus/etc/janus/janus.jcfg
+      - ./config/janus.transport.http.jcfg:/opt/janus/etc/janus/janus.transport.http.jcfg
+      - ./config/janus.eventhandler.sampleevh.jcfg:/opt/janus/etc/janus/janus.eventhandler.sampleevh.jcfg
 #      environment:
 #        - DOCKER_IP=${DOCKER_IP}
-      networks:
-        homer.server:
-
+    networks:
+      homer.server:
 
 # Custom network so all services can communicate using a FQDN
 networks:


### PR DESCRIPTION
Some docker-compose.yml files are messy:

- `restart:` commands specified twice for some services;
- wrong indentation in few places.

This pull request fixes that.