### PR TITLE
pull homer-app and heplify-server images from ghcr.io instead of dockerhub

### DIFF
--- a/heplify-server/hom7-prom-all/docker-compose.yml
+++ b/heplify-server/hom7-prom-all/docker-compose.yml
@@ -114,7 +114,7 @@ services:
         max-size: "50m"
 
   heplify-server:
-    image: sipcapture/heplify-server
+    image: ghcr.io/sipcapture/heplify-server
     container_name: heplify-server
     ports:
       - "9060:9060"
@@ -157,7 +157,7 @@ services:
 
   homer-webapp:
     container_name: homer-webapp
-    image: sipcapture/webapp
+    image: ghcr.io/sipcapture/homer-app
     environment:
       - "LOKI_HOST=loki"
       - "PROM_HOST=prometheus"


### PR DESCRIPTION
pull homer-app and heplify-server images from ghcr.io instead of dockerhub